### PR TITLE
Add launch.json and .vscodeignore files

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,20 @@
+// A launch configuration that compiles the extension and then opens it inside a new window
+// Use IntelliSense to learn about possible attributes.
+// Hover to view descriptions of existing attributes.
+// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+{
+	"version": "0.2.0",
+	"configurations": [{
+			"name": "Run Extension",
+			"type": "extensionHost",
+			"request": "launch",
+			"runtimeExecutable": "${execPath}",
+			"args": [
+				"--extensionDevelopmentPath=${workspaceFolder}"
+			],
+			"outFiles": [
+				"${workspaceFolder}/out/**/*.js"
+			]
+		}
+	]
+}

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,0 +1,6 @@
+.github
+.gitignore
+.vscode
+node_modules
+**/*.ts
+tsconfig.json


### PR DESCRIPTION
This PR adds a couple of useful files for the pro-editing repo:

* `launch.json` - This is just to add a debug configuration that devs might find handy
* `.vscodeignore` - Exclude unnecessary files when packaging our extension